### PR TITLE
Add astroquery (back) in the requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     astroplan>=0.5
     astropy>=3.1,!=4.0.1  # https://github.com/astropy/reproject/pull/227
     astropy-healpix>=0.3  # https://github.com/astropy/astropy-healpix/pull/106
+    astroquery>=0.3.10
     healpy
     h5py
     importlib-resources;python_version<'3.7'


### PR DESCRIPTION
Add "astroquery>=0.3.10" to the requirements in setup.cfg. Without it, running "ligo-skymap-plot --help" results in the following error after installing from source:

>> pkg_resources.DistributionNotFound: The 'beautifulsoup4>=4.3.2' distribution was not found and is required by astroquery

Adding the requirement and re-installing fixes this issue.