### PR TITLE
Add marker options to ligo-skymap-plot.

### DIFF
--- a/ligo/skymap/tool/ligo_skymap_plot.py
+++ b/ligo/skymap/tool/ligo_skymap_plot.py
@@ -45,13 +45,13 @@ def parser():
         '--radec', nargs=2, metavar='deg', type=float, action='append',
         default=[], help='right ascension (deg) and declination (deg) to mark')
     parser.add_argument(
-        '--marker', metavar='matplotlib_marker', default='*', type=str,
+        '--marker', metavar='matplotlib_marker', default='*',
         help='symbol used when marking --radec (has to be one of the matplotlib marker strings)')
     parser.add_argument(
-        '--marker-color', metavar='color_name', default='white', type=str,
-        help='color for the --radec marker')
+        '--marker-face-color', metavar='color_name', default='white',
+        help='face color for the --radec marker')
     parser.add_argument(
-        '--marker-ecolor', metavar='color_name', default='black', type=str,
+        '--marker-edge-color', metavar='color_name', default='black',
         help='edge color for the --radec marker')
     parser.add_argument(
         '--marker-size', metavar='size_int', default=10, type=int,
@@ -65,7 +65,7 @@ def parser():
              'instead of the celestial frame with coordinates (RA, dec) '
              'and draw continents on the map')
     parser.add_argument(
-        '--projection', type=str, default='mollweide',
+        '--projection', default='mollweide',
         choices=['mollweide', 'aitoff', 'globe', 'zoom'],
         help='Projection style')
     parser.add_argument(
@@ -82,7 +82,7 @@ def parser():
     pta_group = parser.add_argument_group('PTA options', 
                         'Options for plotting the pulsars of a Pulsar Timing Array')
     pta_group.add_argument(
-        '--pta-file', metavar='pulsars.csv', type=str,
+        '--pta-file', metavar='pulsars.csv',
         help='path to PTA pulsars file with columns ra, dec (in degrees), '
         'and noise rms (in seconds). The rms column can be left out if '
         'specifying the option --pta-fix-marker-size.')
@@ -90,13 +90,13 @@ def parser():
         '--pta-size', metavar='int', type=int,
         help='Optional when using --pta-file, only plot the first INT pulsar')
     pta_group.add_argument(
-        '--pta-marker', metavar='matplotlib_marker', default='*', type=str,
+        '--pta-marker', metavar='matplotlib_marker', default='*',
         help='symbol used when marking pulsars from --pta-file')
     pta_group.add_argument(
-        '--pta-color', metavar='color_name', default='white', type=str,
-        help='color for the --pta-file markers')
+        '--pta-face-color', metavar='color_name', default='white',
+        help='face color for the --pta-file markers')
     pta_group.add_argument(
-        '--pta-ecolor', metavar='color_name', default='black', type=str,
+        '--pta-edge-color', metavar='color_name', default='black',
         help='edge color for the --pta-file markers')
     pta_group.add_argument(
         '--pta-fix-marker-size', metavar='size_int', default=False,
@@ -197,8 +197,8 @@ def main(args=None):
         ax.plot_coord(
             SkyCoord(ra, dec, unit='deg'), 
             opts.marker,
-            markerfacecolor=opts.marker_color, 
-            markeredgecolor=opts.marker_ecolor,
+            markerfacecolor=opts.marker_face_color, 
+            markeredgecolor=opts.marker_edge_color,
             markersize=opts.marker_size)
         
     # If given, add additional markers for the pulsars from a PTA
@@ -228,8 +228,8 @@ def main(args=None):
             ax.plot_coord(
                 SkyCoord(ra, dec, unit='deg'),
                 opts.pta_marker,
-                markerfacecolor=opts.pta_color,
-                markeredgecolor=opts.pta_ecolor,
+                markerfacecolor=opts.pta_face_color,
+                markeredgecolor=opts.pta_edge_color,
                 markersize=pulsar_sizes[i])
 
     # Add a white outline to all text to make it stand out from the background.

--- a/ligo/skymap/tool/ligo_skymap_plot.py
+++ b/ligo/skymap/tool/ligo_skymap_plot.py
@@ -45,6 +45,18 @@ def parser():
         '--radec', nargs=2, metavar='deg', type=float, action='append',
         default=[], help='right ascension (deg) and declination (deg) to mark')
     parser.add_argument(
+        '--marker', metavar='matplotlib_marker', default='*', type=str,
+        help='symbol used when marking --radec (has to be one of the matplotlib marker strings)')
+    parser.add_argument(
+        '--marker-color', metavar='color_name', default='white', type=str,
+        help='color for the --radec marker')
+    parser.add_argument(
+        '--marker-ecolor', metavar='color_name', default='black', type=str,
+        help='edge color for the --radec marker')
+    parser.add_argument(
+        '--marker-size', metavar='size_int', default=10, type=int,
+        help='size of the --radec marker symbol')
+    parser.add_argument(
         '--inj-database', metavar='FILE.sqlite', type=SQLiteType('r'),
         help='read injection positions from database')
     parser.add_argument(
@@ -156,8 +168,11 @@ def main(args=None):
     # Add markers (e.g., for injections or external triggers).
     for ra, dec in radecs:
         ax.plot_coord(
-            SkyCoord(ra, dec, unit='deg'), '*',
-            markerfacecolor='white', markeredgecolor='black', markersize=10)
+            SkyCoord(ra, dec, unit='deg'), 
+            opts.marker,
+            markerfacecolor=opts.marker_color, 
+            markeredgecolor=opts.marker_ecolor,
+            markersize=opts.marker_size)
 
     # Add a white outline to all text to make it stand out from the background.
     plot.outline_text(ax)


### PR DESCRIPTION
The following options are added that specify shape, color, edge color
and size of the marker used with the --radec option that already
existed:
--marker to specify the symbol
--marker-color for the color
--marker-ecolor for the edge color (outside line of the marker)
--marker-size for the size

Defaults are implemented so that the behaviour does not change when NOT
specifying any of these new options. I.e. by default, --radec plots a
size 10 star ('*') marker in white with a black outline.

Working on: adding options and code to plot locations of PTA pulsars using an input text file with specified locations and pulsar noise levels.