### PR TITLE
start enforcing that the python version is  >= 3.9 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 zip_safe = False
 packages = find_namespace:
-python_version = >=3.9
+python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
     astroplan>=0.7  # https://github.com/astropy/astroplan/issues/479


### PR DESCRIPTION
The latest release of ligo.skymap revealed a mistake in packaging. I believe it was intended that the latest release be restricted to python3.9 or later and that support be dropped for python3.8. 

There is a typo in the setup.cfg file so that the restriction is not actually enforced. This means that attempting to install ligo.skymap from earlier python versions with e.g. pip will download the latest and then fail to build rather than downloading an older compatible version as desired. 

This change request, updates the cfg file to require python3.9 or later.

https://packaging.python.org/en/latest/guides/dropping-older-python-versions/

@lpsinger If you are happy to merge this, I might request to aid downstream packages to release a minor update and take down the source version of the last release. Otherwise, that version will continue to cause problems in older python versions. This is pretty straightforward to do on pypi itself. 