### PR TITLE
lower requirements, allow numpy 2.0 and python 3.9

### DIFF
--- a/ligo/skymap/bayestar/filter.py
+++ b/ligo/skymap/bayestar/filter.py
@@ -25,6 +25,7 @@ import numpy as np
 from scipy import interpolate
 from scipy import fftpack as fft
 from scipy import linalg
+from scipy import integrate
 
 log = logging.getLogger('BAYESTAR')
 
@@ -545,7 +546,7 @@ class SignalModel:
         h = h.data.data[first_nonzero:last_nonzero + 1]
 
         self.denom_integrand = 4 / (2 * np.pi) * h
-        self.den = np.trapezoid(self.denom_integrand, dx=self.dw)
+        self.den = integrate.trapezoid(self.denom_integrand, dx=self.dw)
 
     def get_horizon_distance(self, snr_thresh=1):
         return np.sqrt(self.den) / snr_thresh
@@ -554,7 +555,7 @@ class SignalModel:
         """Get the average of a function of angular frequency, weighted by the
         signal to noise per unit angular frequency.
         """
-        num = np.trapezoid(func(self.w) * self.denom_integrand, dx=self.dw)
+        num = integrate.trapezoid(func(self.w) * self.denom_integrand, dx=self.dw)
         return num / self.den
 
     def get_sn_moment(self, power):

--- a/ligo/skymap/extern/numpy/quantile.py
+++ b/ligo/skymap/extern/numpy/quantile.py
@@ -34,7 +34,7 @@
 import warnings
 
 import numpy as np
-import numpy._core.numeric as _nx
+import numpy.lib.array_utils as _nx
 
 
 def _ureduce(a, func, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,14 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: C",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.09",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.09"
+requires-python = ">=3.9"
 dependencies = [
     "astroplan>=0.7",  # https://github.com/astropy/astroplan/issues/479
     "astropy>=6.0",  # https://github.com/astropy/astropy/pull/14980

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: C",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.09",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.09"
 dependencies = [
     "astroplan>=0.7",  # https://github.com/astropy/astroplan/issues/479
     "astropy>=6.0",  # https://github.com/astropy/astropy/pull/14980

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "ligo-segments>=1.2.0",
     "matplotlib>=3.5.0",  # https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.6.0.html#pending-deprecation-top-level-cmap-registration-and-access-functions-in-mpl-cm
     "networkx",
-    "numpy>=2.0.0",  # https://github.com/astropy/astropy/issues/15095
+    "numpy>=1.23",  # Consistent with current Astropy 6 releases
     "pillow>=2.5.0",
     "ptemcee",
     "python-ligo-lw>=1.8.0",

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,4 @@ per_file_ignores =
     src/bayestar_cosmology.py:N802,N803,N806,N816
 
 [bdist_wheel]
-py_limited_api = cp310
+py_limited_api = cp309

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,3 @@ per_file_ignores =
     ligo/skymap/tool/tests/test_bayestar_inject.py:N803,N806
     ligo/skymap/util/ilwd.py:N802,N803
     src/bayestar_cosmology.py:N802,N803,N806,N816
-
-[bdist_wheel]
-py_limited_api = cp309

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,6 @@ per_file_ignores =
     ligo/skymap/tool/tests/test_bayestar_inject.py:N803,N806
     ligo/skymap/util/ilwd.py:N802,N803
     src/bayestar_cosmology.py:N802,N803,N806,N816
+
+[bdist_wheel]
+py_limited_api = cp39

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def get_extensions():
         'define_macros': [
             ('GSL_RANGE_CHECK_OFF', None),
             ('HAVE_INLINE', None),
+            ('Py_LIMITED_API', 0x03090000),
         ],
         'extra_compile_args': [
             '-std=gnu11',
@@ -58,7 +59,7 @@ def get_extensions():
         kwargs.setdefault(key, []).extend(orig_value)
 
     extension = Extension(name='ligo.skymap.core', language='c',
-                          **kwargs)
+                          py_limited_api=True, **kwargs)
 
     if not os.environ.get('LIGO_SKYMAP_DISABLE_OPENMP'):
         add_openmp_flags_if_available(extension)

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ def get_extensions():
             ('GSL_RANGE_CHECK_OFF', None),
             ('HAVE_INLINE', None),
             ('Py_LIMITED_API', 0x030A0000),
-            ('NPY_TARGET_VERSION', 'NPY_2_0_API_VERSION'),
-            ('NPY_NO_DEPRECATED_API', 'NPY_2_0_API_VERSION'),
         ],
         'extra_compile_args': [
             '-std=gnu11',
@@ -141,8 +139,11 @@ use_scm_version = {'write_to': 'ligo/skymap/version.py',
 # default branch, then disable the local part of the version
 # (+g<short commit hash>) so that we can upload nightly builds to PyPI.
 if (
-    os.environ.get('CI') == 'true' and
-    os.environ.get('CI_COMMIT_BRANCH') == os.environ['CI_DEFAULT_BRANCH']
+    try:
+        os.environ.get('CI') == 'true' and
+        os.environ.get('CI_COMMIT_BRANCH') == os.environ['CI_DEFAULT_BRANCH']
+    except KeyError:
+        use_scm_version['local_scheme'] = 'no-local-version'
 ):
     use_scm_version['local_scheme'] = 'no-local-version'
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_extensions():
         'define_macros': [
             ('GSL_RANGE_CHECK_OFF', None),
             ('HAVE_INLINE', None),
-            ('Py_LIMITED_API', 0x030A0000),
+            ('Py_LIMITED_API', 0x03090000),
         ],
         'extra_compile_args': [
             '-std=gnu11',

--- a/setup.py
+++ b/setup.py
@@ -139,11 +139,8 @@ use_scm_version = {'write_to': 'ligo/skymap/version.py',
 # default branch, then disable the local part of the version
 # (+g<short commit hash>) so that we can upload nightly builds to PyPI.
 if (
-    try:
-        os.environ.get('CI') == 'true' and
-        os.environ.get('CI_COMMIT_BRANCH') == os.environ['CI_DEFAULT_BRANCH']
-    except KeyError:
-        use_scm_version['local_scheme'] = 'no-local-version'
+    os.environ.get('CI') == 'true' and "CI_DEFAULT_BRANCH" in os.environ and
+    os.environ.get('CI_COMMIT_BRANCH') == os.environ['CI_DEFAULT_BRANCH']
 ):
     use_scm_version['local_scheme'] = 'no-local-version'
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ def get_extensions():
         'define_macros': [
             ('GSL_RANGE_CHECK_OFF', None),
             ('HAVE_INLINE', None),
-            ('Py_LIMITED_API', 0x03090000),
         ],
         'extra_compile_args': [
             '-std=gnu11',
@@ -59,7 +58,7 @@ def get_extensions():
         kwargs.setdefault(key, []).extend(orig_value)
 
     extension = Extension(name='ligo.skymap.core', language='c',
-                          py_limited_api=True, **kwargs)
+                          **kwargs)
 
     if not os.environ.get('LIGO_SKYMAP_DISABLE_OPENMP'):
         add_openmp_flags_if_available(extension)


### PR DESCRIPTION
This enables the current version of ligo.skymap to run under python 3.9 and more importantly to be able to run with numpy < 2.0. Numpy has built-in ABI backwards compatibility in 2.0, so it will still build against 2.0 per the numpy guidance, but no longer restricts from using older numpy versions.

This change allows us to use and test ligo.skymap with a wider range of environments in combination with libraries like PyCBC for still supported versions of python / numpy as given by the numpy versioning guidance. As far as I can tell, ligo.skymap works as intended for the cases I could test (e.g. making skymaps from candidate events). 